### PR TITLE
Fixed the requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-requests==2.7.0
-python-dateutil==2.4.2
-six==1.9.0
+requests>=2.7.0
+python-dateutil>=2.4.2
+six>=1.9.0
+responses>=0.5.1

--- a/setup.py
+++ b/setup.py
@@ -68,10 +68,10 @@ setup(
         'pytest-runner'
     ],
     install_requires=[
-        'requests==2.7.0',
-        'python-dateutil==2.4.2',
-        'six==1.9.0',
-        'responses==0.5.1'
+        'requests>=2.7.0',
+        'python-dateutil>=2.4.2',
+        'six>=1.9.0',
+        'responses>=0.5.1'
     ],
     tests_require=[
         'pytest'


### PR DESCRIPTION
Some of the requirements were outdated (severely), so have updated them, with `>=`.
Also `responses` was missing from requirements.txt.

Tests have passed with the latest versions of the dependencies.