### PR TITLE
Update requests version

### DIFF
--- a/postmen/__init__.py
+++ b/postmen/__init__.py
@@ -124,7 +124,7 @@ class Postmen(object):
         self._endpoint = endpoint if endpoint else 'https://%s-api.postmen.com' % region
         self._headers = {'content-type': 'application/json'}
         self._headers['postmen-api-key'] = api_key
-        self._headers['x-postmen-agent'] = 'python-sdk-1.2'
+        self._headers['x-postmen-agent'] = 'python-sdk-1.3'
         self._raw = raw
         self._safe = safe
         self._time = time

--- a/postmen/test/postmen_test.py
+++ b/postmen/test/postmen_test.py
@@ -21,7 +21,7 @@ global call
 @responses.activate
 def testNotRaiseException() :
     response = '{"meta":{"code":200,"message":"OK","details":[]},"data":{}}'
-    responses.add(responses.GET, 'https://REGION-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200)
+    responses.add(responses.GET, 'https://region-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200)
     api = Postmen('KEY', 'REGION')
     api.get('labels')
     responses.reset()
@@ -30,7 +30,7 @@ def testNotRaiseException() :
 @responses.activate
 def testNonSerializableJSON():
     response = 'THIS IS NOT A VALID JSON OBJECT'
-    responses.add(responses.GET, 'https://REGION-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200, content_type='text/plain')
+    responses.add(responses.GET, 'https://region-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200, content_type='text/plain')
     api = Postmen('KEY', 'REGION')
     with pytest.raises(PostmenException) as e:
         api.get('labels')
@@ -43,7 +43,7 @@ def testNonSerializableJSON():
 @responses.activate
 def testException3():
     response = '{"meta":{"code":999,"message":"PROBLEM","retryable":true,"details":[]},"data":{}}'
-    responses.add(responses.GET, 'https://REGION-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200)
+    responses.add(responses.GET, 'https://region-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200)
     api = Postmen('KEY', 'REGION')
     with pytest.raises(PostmenException) as e:
         api.get('labels')
@@ -56,7 +56,7 @@ def testException3():
 @responses.activate
 def testException4():
     response = '{"meta":{"code":999,"message":"PROBLEM","retryable":false,"details":[]},"data":{}}'
-    responses.add(responses.GET, 'https://REGION-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200)
+    responses.add(responses.GET, 'https://region-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200)
     api = Postmen('KEY', 'REGION')
     with pytest.raises(PostmenException) as e:
         api.get('labels')
@@ -69,7 +69,7 @@ def testException4():
 @responses.activate
 def testException5():
     response = '{"meta":{"code":999,"message":"PROBLEM","retryable":false,"details":[{"key":"value"}]},"data":{}}'
-    responses.add(responses.GET, 'https://REGION-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200)
+    responses.add(responses.GET, 'https://region-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200)
     api = Postmen('KEY', 'REGION')
     with pytest.raises(PostmenException) as e:
         api.get('labels')
@@ -84,7 +84,7 @@ def testException5():
 @responses.activate
 def testException6():
     response = '{"meta":{"code":200,"message":"OK","details":[]},"data":{}}'
-    responses.add(responses.GET, 'https://REGION-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200)
+    responses.add(responses.GET, 'https://region-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200)
     api = CrashPostmen('KEY', 'REGION')
     with pytest.raises(PostmenException) as e:
         api.get('labels')
@@ -96,7 +96,7 @@ def testException6():
 @responses.activate
 def testArguments7():
     response = '{"meta":{"code":999,"message":"NOT OK","details":[]},"data":{}}'
-    responses.add(responses.GET, 'https://REGION-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200, content_type='text/plain')
+    responses.add(responses.GET, 'https://region-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200, content_type='text/plain')
     api = Postmen('KEY', 'REGION')
     api.get('labels', safe=True)
     responses.reset()
@@ -120,7 +120,7 @@ def testRetryDelay():
         elif call == 2 :
             call = 3
             return (200, headers,  '{"meta":{"code":200,"message":"OK","details":[]},"data":{}}')
-    responses.add_callback(responses.GET, 'https://REGION-api.postmen.com/v3/labels', callback=request_callback)
+    responses.add_callback(responses.GET, 'https://region-api.postmen.com/v3/labels', callback=request_callback)
     api = Postmen('KEY', 'REGION')
     api.get('labels')
     responses.reset()
@@ -138,7 +138,7 @@ def testRetryMaxAttempt(monkeypatch):
             return (200, headers,  '{"meta":{"code":999,"message":"PROBLEM","retryable":true, "details":[]},"data":{}}')
         else :
             return (200, headers,  '{"meta":{"code":200,"message":"OK","details":[]},"data":{}}')
-    responses.add_callback(responses.GET, 'https://REGION-api.postmen.com/v3/labels', callback=request_callback)
+    responses.add_callback(responses.GET, 'https://region-api.postmen.com/v3/labels', callback=request_callback)
     api = Postmen('KEY', 'REGION')
     before = time.time()
     api.get('labels')
@@ -159,7 +159,7 @@ def testRetryMaxAttemptExceeded(monkeypatch):
             return (200, headers,  '{"meta":{"code":999,"message":"PROBLEM","retryable":true, "details":[]},"data":{}}')
         else :
             pytest.fail("Maximum 5 attempts of retry, test #10 failed")
-    responses.add_callback(responses.GET, 'https://REGION-api.postmen.com/v3/labels', callback=request_callback)
+    responses.add_callback(responses.GET, 'https://region-api.postmen.com/v3/labels', callback=request_callback)
     api = Postmen('KEY', 'REGION')
     with pytest.raises(PostmenException) as e:
         api.get('labels')
@@ -181,7 +181,7 @@ def testArguments11(monkeypatch):
             return (200, headers,  '{"meta":{"code":999,"message":"PROBLEM","retryable":true, "details":[]},"data":{}}')
         else :
             pytest.fail("Shall not retry if retry = False, test #11 failed")
-    responses.add_callback(responses.GET, 'https://REGION-api.postmen.com/v3/labels', callback=request_callback)
+    responses.add_callback(responses.GET, 'https://region-api.postmen.com/v3/labels', callback=request_callback)
     api = Postmen('KEY', 'REGION', retry=False)
     with pytest.raises(PostmenException) as e:
         api.get('labels')
@@ -204,7 +204,7 @@ def testArgument12(monkeypatch):
             return (200, headers,  '{"meta":{"code":999,"message":"PROBLEM","retryable":false, "details":[]},"data":{}}')
         elif call == 1 :
             pytest.fail("Shall not retry if non retryable, test #12 failed")
-    responses.add_callback(responses.GET, 'https://REGION-api.postmen.com/v3/labels', callback=request_callback)
+    responses.add_callback(responses.GET, 'https://region-api.postmen.com/v3/labels', callback=request_callback)
     api = Postmen('KEY', 'REGION')
     with pytest.raises(PostmenException) as e:
         api.get('labels')
@@ -227,7 +227,7 @@ def testRateLimit(monkeypatch):
             return (200, exceeded,  '{"meta":{"code":429,"message":"EXCEEDED","retryable":true, "details":[]},"data":{}}')
         elif call == 1 :
             return (200, headers,  '{"meta":{"code":200,"message":"OK","details":[]},"data":{}}')
-    responses.add_callback(responses.GET, 'https://REGION-api.postmen.com/v3/labels', callback=request_callback)
+    responses.add_callback(responses.GET, 'https://region-api.postmen.com/v3/labels', callback=request_callback)
     api = Postmen('KEY', 'REGION')
     api.get('labels')
     responses.reset()
@@ -237,7 +237,7 @@ def testRateLimit(monkeypatch):
 @responses.activate
 def testArgument14():
     response = '{"meta":{"code":429,"message":"EXCEEDED","retryable":true, "details":[]},"data":{}}'
-    responses.add(responses.GET, 'https://REGION-api.postmen.com/v3/labels', adding_headers=exceeded, body=response, status=200)
+    responses.add(responses.GET, 'https://region-api.postmen.com/v3/labels', adding_headers=exceeded, body=response, status=200)
     api = Postmen('KEY', 'REGION', rate=False)
     with pytest.raises(PostmenException) as e:
         api.get('labels')
@@ -250,7 +250,7 @@ def testArgument14():
 @responses.activate
 def testIncorrectResponseHeaders():
     response = '{"meta":{"code":200,"message":"OK","details":[]},"data":{"key":"value"}}'
-    responses.add(responses.GET, 'https://REGION-api.postmen.com/v3/labels', adding_headers=incorrect, body=response, status=200)
+    responses.add(responses.GET, 'https://region-api.postmen.com/v3/labels', adding_headers=incorrect, body=response, status=200)
     api = Postmen('KEY', 'REGION')
     ret = api.get('labels')
     assert ret['key'] == 'value'
@@ -271,7 +271,7 @@ def testArgument16():
 @responses.activate
 def testArgument17() :
     response = '{"meta":{"code":200,"message":"OK","details":[]},"data":{}}'
-    responses.add(responses.GET, 'https://REGION-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200)
+    responses.add(responses.GET, 'https://region-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200)
     api = Postmen('KEY', 'REGION', raw=True)
     ret = api.get('labels')
     assert ret == response
@@ -281,7 +281,7 @@ def testArgument17() :
 @responses.activate
 def testArgument18() :
     response = '{"meta":{"code":999,"message":"NOT OK","details":[]},"data":{}}'
-    responses.add(responses.GET, 'https://REGION-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200)
+    responses.add(responses.GET, 'https://region-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200)
     api = Postmen('KEY', 'REGION', raw=True)
     ret = api.get('labels')
     assert ret == response
@@ -403,7 +403,7 @@ def testQuery():
 @responses.activate
 def testTime():
     response = '{"meta":{"code":200,"message":"OK","details":[]},"data":{"when": "2016-01-31T16:45:46+00:00"}}'
-    responses.add(responses.GET, 'https://REGION-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200, content_type='text/plain')
+    responses.add(responses.GET, 'https://region-api.postmen.com/v3/labels', adding_headers=headers, body=response, status=200, content_type='text/plain')
     api = Postmen('KEY', 'REGION')
     res = api.get('labels')
     assert res['when'] == '2016-01-31T16:45:46+00:00'

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         'pytest-runner'
     ],
     install_requires=[
-        'requests>=2.7.0,<2.12',
+        'requests>=2.7.0',
         'python-dateutil>=2.4.2',
         'six>=1.9.0',
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     # Versions should comply with PEP440. For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='1.2',
+    version='1.3',
 
     description='Python SDK of Postmen API',
     long_description=long_description,
@@ -23,7 +23,7 @@ setup(
     url='https://github.com/postmen/sdk-python',
 
     # Download path
-    download_url = 'https://github.com/postmen/sdk-python/tarball/1.2',
+    download_url = 'https://github.com/postmen/sdk-python/tarball/1.3',
 
     # Author details
     author='Postmen',


### PR DESCRIPTION
Remove the version pin on requests (`2.12` is old - Nov 2016).

* Updated URLs for `responses`: some normalisation is done and this was causing the mocked responses to fail.
* The build seems to be broken for python 3.3: see the Travis report for the first commit 4cc573d in this PR.